### PR TITLE
Inject additional hosts l0 alias

### DIFF
--- a/resources/scripts/installer.sh
+++ b/resources/scripts/installer.sh
@@ -3,8 +3,9 @@
 set -x
 
 # Prepare /etc/hosts
-sudo sed -i 's/\(^[0-9.]*\).*\.c\.kmo-instruqt\.internal/\1 puppet.c.kmo-instruqt.internal/' /etc/hosts
-sudo sed -i 's/\(puppet\.c\.kmo-instruqt\.internal\).*/\1 puppet/' /etc/hosts
+# sudo sed -i 's/\(^[0-9.]*\).*\.c\.kmo-instruqt\.internal/\1 puppet.c.kmo-instruqt.internal/' /etc/hosts
+# sudo sed -i 's/\(puppet\.c\.kmo-instruqt\.internal\).*/\1 puppet/' /etc/hosts
+sudo echo "127.0.0.1 puppet.c.kmo-instruqt.internal puppet" >> /etc/hosts
 
 #Change the hostname to the FQDN of the master
 sudo hostnamectl set-hostname puppet


### PR DESCRIPTION
This replaces the sed commands with an additional alias to 127.0.0.1 using the append command

It results in a working build on both GCP and Instruqt

The only thing that looks weird is the `facter clientcert` command still comes up empty, but I don't know if that will be a problem.